### PR TITLE
fix: do not leave ffmpeg stdin open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.3 - Unreleased
 
+- Pass `-nostdin` and ignore stdin when spawning ffmpeg so auto and
+  external encode fallback does not wait on a leftover pipe.
+- Free Photon images when decoded dimensions exceed the pixel budget.
+
 ## 0.3.2 - 2026-08-09
 
 **Highlight:** HEIF and AVIF images now keep their orientation. Rotated or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Pass `-nostdin` and ignore stdin when spawning ffmpeg so auto and
   external encode fallback does not wait on a leftover pipe.
+- Apply `maxProcessBufferBytes` independently to stdout and stderr,
+  matching execFile's per-stream `maxBuffer`.
 - Free Photon images when decoded dimensions exceed the pixel budget.
 
 ## 0.3.2 - 2026-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 0.3.3 - Unreleased
 
-- Pass `-nostdin` and ignore stdin when spawning ffmpeg so auto and
-  external encode fallback does not wait on a leftover pipe.
-- Apply `maxProcessBufferBytes` independently to stdout and stderr,
-  matching execFile's per-stream `maxBuffer`.
-- Free Photon images when decoded dimensions exceed the pixel budget.
-
 ## 0.3.2 - 2026-08-09
 
 **Highlight:** HEIF and AVIF images now keep their orientation. Rotated or

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,8 @@
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
 import { deflateSync, inflateSync } from "node:zlib";
-
-const execFileAsync = promisify(execFile);
 
 type PhotonModule = typeof import("@silvia-odwyer/photon-node");
 type PhotonImage = InstanceType<PhotonModule["PhotonImage"]>;
@@ -1459,7 +1456,15 @@ async function loadOrientedPhotonImage(
       grayscaleAlpha.height,
     );
   }
-  validatePixelBudget({ width: decoded.get_width(), height: decoded.get_height() }, maxInputPixels);
+  try {
+    validatePixelBudget(
+      { width: decoded.get_width(), height: decoded.get_height() },
+      maxInputPixels,
+    );
+  } catch (error) {
+    decoded.free();
+    throw error;
+  }
   return { photon, image: autoOrient ? applyExifOrientation(photon, decoded, buffer) : decoded };
 }
 
@@ -1982,10 +1987,53 @@ async function runTool(
   options: ResolvedOptions,
   signal?: AbortSignal,
 ): Promise<void> {
-  await execFileAsync(command, args, {
-    timeout: options.timeoutMs,
-    maxBuffer: options.maxProcessBufferBytes,
-    ...(signal === undefined ? {} : { signal }),
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      fn();
+    };
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: options.timeoutMs,
+      ...(signal === undefined ? {} : { signal }),
+    });
+    const stderrChunks: Buffer[] = [];
+    let stderrBytes = 0;
+    child.stdout?.resume();
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes <= options.maxProcessBufferBytes) {
+        stderrChunks.push(chunk);
+      }
+    });
+    child.on("error", (error) => {
+      finish(() => {
+        reject(error);
+      });
+    });
+    child.on("close", (code, killSignal) => {
+      if (code === 0) {
+        finish(() => {
+          resolve();
+        });
+        return;
+      }
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      finish(() => {
+        reject(
+          Object.assign(new Error(`Command failed: ${command}\n${stderr}`), {
+            code,
+            killed: child.killed,
+            signal: killSignal,
+            stderr,
+          }),
+        );
+      });
+    });
   });
 }
 
@@ -2042,6 +2090,10 @@ function convertResizeArgs(native: NativeEncodeOptions): string[] {
 
 function convertStripArgs(): string[] {
   return ["-strip"];
+}
+
+function ffmpegCommonArgs(): string[] {
+  return ["-nostdin", "-y"];
 }
 
 function ffmpegStripArgs(): string[] {
@@ -2268,7 +2320,7 @@ async function externalToJpeg(
       await runTool(
         tool.command,
         [
-          "-y",
+          ...ffmpegCommonArgs(),
           "-i",
           input,
           ...ffmpegStripArgs(),
@@ -2349,7 +2401,7 @@ async function externalToWebp(
       await runTool(
         tool.command,
         [
-          "-y",
+          ...ffmpegCommonArgs(),
           "-i",
           input,
           ...ffmpegStripArgs(),
@@ -2414,7 +2466,7 @@ async function externalConvertToJpeg(
       await runTool(
         tool.command,
         [
-          "-y",
+          ...ffmpegCommonArgs(),
           "-i",
           input,
           ...ffmpegStripArgs(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
-import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { deflateSync, inflateSync } from "node:zlib";
+
+const execFileAsync = promisify(execFile);
 
 type PhotonModule = typeof import("@silvia-odwyer/photon-node");
 type PhotonImage = InstanceType<PhotonModule["PhotonImage"]>;
@@ -1987,74 +1990,10 @@ async function runTool(
   options: ResolvedOptions,
   signal?: AbortSignal,
 ): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const finish = (fn: () => void): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      fn();
-    };
-    const child = spawn(command, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: options.timeoutMs,
-      ...(signal === undefined ? {} : { signal }),
-    });
-    const stderrChunks: Buffer[] = [];
-    let overflowed = false;
-    const consume = (stream: NodeJS.ReadableStream | null, keep: boolean): void => {
-      let capturedBytes = 0;
-      stream?.on("data", (chunk: Buffer) => {
-        capturedBytes += chunk.length;
-        if (capturedBytes > options.maxProcessBufferBytes) {
-          overflowed = true;
-          child.kill();
-          return;
-        }
-        if (keep) {
-          stderrChunks.push(chunk);
-        }
-      });
-    };
-    consume(child.stdout, false);
-    consume(child.stderr, true);
-    child.on("error", (error) => {
-      finish(() => {
-        reject(error);
-      });
-    });
-    child.on("close", (code, killSignal) => {
-      if (overflowed) {
-        finish(() => {
-          reject(
-            Object.assign(new Error(`Command exceeded maxProcessBufferBytes: ${command}`), {
-              code: "ERR_BUFFER_OVERFLOW",
-              killed: child.killed,
-              signal: killSignal,
-            }),
-          );
-        });
-        return;
-      }
-      if (code === 0) {
-        finish(() => {
-          resolve();
-        });
-        return;
-      }
-      const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      finish(() => {
-        reject(
-          Object.assign(new Error(`Command failed: ${command}\n${stderr}`), {
-            code,
-            killed: child.killed,
-            signal: killSignal,
-            stderr,
-          }),
-        );
-      });
-    });
+  await execFileAsync(command, args, {
+    timeout: options.timeoutMs,
+    maxBuffer: options.maxProcessBufferBytes,
+    ...(signal === undefined ? {} : { signal }),
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2002,20 +2002,41 @@ async function runTool(
       ...(signal === undefined ? {} : { signal }),
     });
     const stderrChunks: Buffer[] = [];
-    let stderrBytes = 0;
-    child.stdout?.resume();
-    child.stderr?.on("data", (chunk: Buffer) => {
-      stderrBytes += chunk.length;
-      if (stderrBytes <= options.maxProcessBufferBytes) {
-        stderrChunks.push(chunk);
-      }
-    });
+    let capturedBytes = 0;
+    let overflowed = false;
+    const consume = (stream: NodeJS.ReadableStream | null, keep: boolean): void => {
+      stream?.on("data", (chunk: Buffer) => {
+        capturedBytes += chunk.length;
+        if (capturedBytes > options.maxProcessBufferBytes) {
+          overflowed = true;
+          child.kill();
+          return;
+        }
+        if (keep) {
+          stderrChunks.push(chunk);
+        }
+      });
+    };
+    consume(child.stdout, false);
+    consume(child.stderr, true);
     child.on("error", (error) => {
       finish(() => {
         reject(error);
       });
     });
     child.on("close", (code, killSignal) => {
+      if (overflowed) {
+        finish(() => {
+          reject(
+            Object.assign(new Error(`Command exceeded maxProcessBufferBytes: ${command}`), {
+              code: "ERR_BUFFER_OVERFLOW",
+              killed: child.killed,
+              signal: killSignal,
+            }),
+          );
+        });
+        return;
+      }
       if (code === 0) {
         finish(() => {
           resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2002,9 +2002,9 @@ async function runTool(
       ...(signal === undefined ? {} : { signal }),
     });
     const stderrChunks: Buffer[] = [];
-    let capturedBytes = 0;
     let overflowed = false;
     const consume = (stream: NodeJS.ReadableStream | null, keep: boolean): void => {
+      let capturedBytes = 0;
       stream?.on("data", (chunk: Buffer) => {
         capturedBytes += chunk.length;
         if (capturedBytes > options.maxProcessBufferBytes) {

--- a/test/rastermill.test.ts
+++ b/test/rastermill.test.ts
@@ -1306,6 +1306,35 @@ describe("Rastermill", () => {
     }
   });
 
+  it("rejects external tools that exceed maxProcessBufferBytes even on exit 0", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-buffer-cap-"));
+    try {
+      const log = path.join(tmp, "args.jsonl");
+      const script = path.join(tmp, "ffmpeg.js");
+      await writeImageToolScript(script, log, { jpeg: jpegWithAppMetadata(4, 2) });
+      await writeFile(
+        script,
+        `${await readFile(script, "utf8")}\nprocess.stderr.write("x".repeat(256));\nprocess.stdout.write("y".repeat(256));\n`,
+        "utf8",
+      );
+      const rastermill = createRastermill({
+        execution: "external",
+        maxProcessBufferBytes: 64,
+        commandResolver: (command) => (command === "ffmpeg" ? script : null),
+      });
+
+      await expect(
+        rastermill.encode(rgbaImage(8, 4), {
+          format: "jpeg",
+          resize: { maxSide: 4 },
+          quality: 70,
+        }),
+      ).rejects.toThrow(/maxProcessBufferBytes/);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("passes -nostdin and ignores stdin on every ffmpeg encode path", async () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-ffmpeg-stdin-"));
     try {

--- a/test/rastermill.test.ts
+++ b/test/rastermill.test.ts
@@ -1288,6 +1288,7 @@ describe("Rastermill", () => {
         resize: { maxSide: 4 },
         quality: 60,
       });
+      await rastermill.encode(heifLikeImage({ width: 4, height: 2 }), { format: "jpeg" });
 
       expect(jpeg).toMatchObject({ format: "jpeg", width: 4, height: 2 });
       expect(webp).toMatchObject({ format: "webp", width: 4, height: 2 });
@@ -1295,127 +1296,14 @@ describe("Rastermill", () => {
         .trim()
         .split("\n")
         .map((line) => JSON.parse(line) as string[]);
+      expect(invocations).toHaveLength(3);
       expect(invocations[0]).toContain("-q:v");
       expect(invocations[0]).toContain("-map_metadata");
       expect(invocations[0]).toContain("-nostdin");
       expect(invocations[1]).toContain("-quality");
       expect(invocations[1]).toContain("60");
       expect(invocations[1]).toContain("-nostdin");
-    } finally {
-      await rm(tmp, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps maxProcessBufferBytes independent per stream", async () => {
-    const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-buffer-per-stream-"));
-    try {
-      const log = path.join(tmp, "args.jsonl");
-      const script = path.join(tmp, "ffmpeg.js");
-      await writeImageToolScript(script, log, { jpeg: jpegWithAppMetadata(4, 2) });
-      await writeFile(
-        script,
-        `${await readFile(script, "utf8")}\nprocess.stderr.write("e".repeat(50));\nprocess.stdout.write("o".repeat(50));\n`,
-        "utf8",
-      );
-      const rastermill = createRastermill({
-        execution: "external",
-        maxProcessBufferBytes: 64,
-        commandResolver: (command) => (command === "ffmpeg" ? script : null),
-      });
-
-      await expect(
-        rastermill.encode(rgbaImage(8, 4), {
-          format: "jpeg",
-          resize: { maxSide: 4 },
-          quality: 70,
-        }),
-      ).resolves.toMatchObject({ format: "jpeg", width: 4, height: 2 });
-    } finally {
-      await rm(tmp, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects external tools that exceed maxProcessBufferBytes even on exit 0", async () => {
-    const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-buffer-cap-"));
-    try {
-      const log = path.join(tmp, "args.jsonl");
-      const script = path.join(tmp, "ffmpeg.js");
-      await writeImageToolScript(script, log, { jpeg: jpegWithAppMetadata(4, 2) });
-      await writeFile(
-        script,
-        `${await readFile(script, "utf8")}\nprocess.stderr.write("x".repeat(256));\nprocess.stdout.write("y".repeat(256));\n`,
-        "utf8",
-      );
-      const rastermill = createRastermill({
-        execution: "external",
-        maxProcessBufferBytes: 64,
-        commandResolver: (command) => (command === "ffmpeg" ? script : null),
-      });
-
-      await expect(
-        rastermill.encode(rgbaImage(8, 4), {
-          format: "jpeg",
-          resize: { maxSide: 4 },
-          quality: 70,
-        }),
-      ).rejects.toThrow(/maxProcessBufferBytes/);
-    } finally {
-      await rm(tmp, { recursive: true, force: true });
-    }
-  });
-
-  it("passes -nostdin and ignores stdin on every ffmpeg encode path", async () => {
-    const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-ffmpeg-stdin-"));
-    try {
-      const log = path.join(tmp, "probe.jsonl");
-      const script = path.join(tmp, "ffmpeg.js");
-      await writeFile(
-        script,
-        [
-          "#!/usr/bin/env node",
-          "const fs = require('node:fs');",
-          "const args = process.argv.slice(2);",
-          "let stdinKind = 'unknown';",
-          "try {",
-          "  const stat = fs.fstatSync(0);",
-          "  stdinKind = stat.isFIFO() ? 'fifo' : stat.isCharacterDevice() ? 'char' : 'other';",
-          "} catch (error) {",
-          "  stdinKind = String(error && error.code ? error.code : error);",
-          "}",
-          `fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({ args, stdinKind }) + '\\n');`,
-          "const output = args.at(-1);",
-          `const jpeg = ${JSON.stringify(jpegWithAppMetadata(4, 2).toString("base64"))};`,
-          `const webp = ${JSON.stringify(losslessWebpHeader(4, 2, false).toString("base64"))};`,
-          "const payload = output.endsWith('.webp') ? webp : jpeg;",
-          "fs.writeFileSync(output, Buffer.from(payload, 'base64'));",
-        ].join("\n"),
-        "utf8",
-      );
-      await chmod(script, 0o755);
-      const rastermill = createRastermill({
-        execution: "external",
-        commandResolver: (command) => (command === "ffmpeg" ? script : null),
-      });
-
-      await rastermill.encode(rgbaImage(8, 4), {
-        format: "jpeg",
-        resize: { maxSide: 4 },
-      });
-      await rastermill.encode(rgbaImage(8, 4), {
-        format: "webp",
-        resize: { maxSide: 4 },
-      });
-      await rastermill.encode(heifLikeImage({ width: 4, height: 2 }), { format: "jpeg" });
-
-      const invocations = (await readFile(log, "utf8"))
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as { args: string[]; stdinKind: string });
-      expect(invocations).toHaveLength(3);
-      for (const invocation of invocations) {
-        expect(invocation.args).toContain("-nostdin");
-        expect(invocation.stdinKind).toBe("char");
-      }
+      expect(invocations[2]).toContain("-nostdin");
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/test/rastermill.test.ts
+++ b/test/rastermill.test.ts
@@ -1297,8 +1297,67 @@ describe("Rastermill", () => {
         .map((line) => JSON.parse(line) as string[]);
       expect(invocations[0]).toContain("-q:v");
       expect(invocations[0]).toContain("-map_metadata");
+      expect(invocations[0]).toContain("-nostdin");
       expect(invocations[1]).toContain("-quality");
       expect(invocations[1]).toContain("60");
+      expect(invocations[1]).toContain("-nostdin");
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("passes -nostdin and ignores stdin on every ffmpeg encode path", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-ffmpeg-stdin-"));
+    try {
+      const log = path.join(tmp, "probe.jsonl");
+      const script = path.join(tmp, "ffmpeg.js");
+      await writeFile(
+        script,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const args = process.argv.slice(2);",
+          "let stdinKind = 'unknown';",
+          "try {",
+          "  const stat = fs.fstatSync(0);",
+          "  stdinKind = stat.isFIFO() ? 'fifo' : stat.isCharacterDevice() ? 'char' : 'other';",
+          "} catch (error) {",
+          "  stdinKind = String(error && error.code ? error.code : error);",
+          "}",
+          `fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({ args, stdinKind }) + '\\n');`,
+          "const output = args.at(-1);",
+          `const jpeg = ${JSON.stringify(jpegWithAppMetadata(4, 2).toString("base64"))};`,
+          `const webp = ${JSON.stringify(losslessWebpHeader(4, 2, false).toString("base64"))};`,
+          "const payload = output.endsWith('.webp') ? webp : jpeg;",
+          "fs.writeFileSync(output, Buffer.from(payload, 'base64'));",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(script, 0o755);
+      const rastermill = createRastermill({
+        execution: "external",
+        commandResolver: (command) => (command === "ffmpeg" ? script : null),
+      });
+
+      await rastermill.encode(rgbaImage(8, 4), {
+        format: "jpeg",
+        resize: { maxSide: 4 },
+      });
+      await rastermill.encode(rgbaImage(8, 4), {
+        format: "webp",
+        resize: { maxSide: 4 },
+      });
+      await rastermill.encode(heifLikeImage({ width: 4, height: 2 }), { format: "jpeg" });
+
+      const invocations = (await readFile(log, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { args: string[]; stdinKind: string });
+      expect(invocations).toHaveLength(3);
+      for (const invocation of invocations) {
+        expect(invocation.args).toContain("-nostdin");
+        expect(invocation.stdinKind).toBe("char");
+      }
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }
@@ -1614,6 +1673,45 @@ describe("Rastermill", () => {
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("frees Photon images when decoded dimensions exceed the pixel budget", async () => {
+    vi.resetModules();
+    const free = vi.fn<() => void>();
+    vi.doMock("@silvia-odwyer/photon-node", () => {
+      class MockPhotonImage {
+        static new_from_byteslice = vi.fn<() => MockPhotonImage>(() => new MockPhotonImage());
+        free(): void {
+          free();
+        }
+        get_height(): number {
+          return 1000;
+        }
+        get_raw_pixels(): Uint8Array {
+          return new Uint8Array(4);
+        }
+        get_width(): number {
+          return 1000;
+        }
+      }
+      return {
+        PhotonImage: MockPhotonImage,
+        SamplingFilter: {
+          Lanczos3: 1,
+        },
+        crop: vi.fn<(image: MockPhotonImage) => MockPhotonImage>((image) => image),
+        resize: vi.fn<(image: MockPhotonImage) => MockPhotonImage>((image) => image),
+      };
+    });
+    const { createRastermill: createFreshRastermill, encodePngRgba: encodeFreshPngRgba } =
+      await import("../src/index.js");
+    const rastermill = createFreshRastermill({ limits: { inputPixels: 100 } });
+    const source = encodeFreshPngRgba(new Uint8Array(4 * 4 * 4), 4, 4);
+
+    await expect(rastermill.encode(source, { format: "jpeg" })).rejects.toMatchObject({
+      code: "RASTERMILL_INPUT_TOO_LARGE",
+    });
+    expect(free).toHaveBeenCalled();
   });
 
   it("rejects images over the configured pixel budget before decoding", async () => {

--- a/test/rastermill.test.ts
+++ b/test/rastermill.test.ts
@@ -1306,6 +1306,35 @@ describe("Rastermill", () => {
     }
   });
 
+  it("keeps maxProcessBufferBytes independent per stream", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-buffer-per-stream-"));
+    try {
+      const log = path.join(tmp, "args.jsonl");
+      const script = path.join(tmp, "ffmpeg.js");
+      await writeImageToolScript(script, log, { jpeg: jpegWithAppMetadata(4, 2) });
+      await writeFile(
+        script,
+        `${await readFile(script, "utf8")}\nprocess.stderr.write("e".repeat(50));\nprocess.stdout.write("o".repeat(50));\n`,
+        "utf8",
+      );
+      const rastermill = createRastermill({
+        execution: "external",
+        maxProcessBufferBytes: 64,
+        commandResolver: (command) => (command === "ffmpeg" ? script : null),
+      });
+
+      await expect(
+        rastermill.encode(rgbaImage(8, 4), {
+          format: "jpeg",
+          resize: { maxSide: 4 },
+          quality: 70,
+        }),
+      ).resolves.toMatchObject({ format: "jpeg", width: 4, height: 2 });
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("rejects external tools that exceed maxProcessBufferBytes even on exit 0", async () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), "rastermill-buffer-cap-"));
     try {


### PR DESCRIPTION
ffmpeg fallback used `execFile` and left stdin as an open pipe, with no `-nostdin`. That is the documented ffmpeg hang class: the child waits on stdin (overwrite prompt, interactive quit, older builds) until `timeoutMs` (default 20s) even when the input file is valid.

## What Problem This Solves

Public `encode` with `execution: "auto"` or `"external"` can fall through to ffmpeg for JPEG and WebP. Node `execFile` always attaches a pipe to stdin. ffmpeg treats an open stdin as interactive input unless `-nostdin` is set or fd 0 is `/dev/null`.

The hang is easy to hit when ffmpeg would ask a question (output already exists) and is still a footgun on valid files: the write end of the pipe stays open in the parent for the whole run. Rastermill already passes `-y` and a file path, but it never closed or ignored stdin and never passed `-nostdin`.

This patch:

- Puts `-nostdin` on every ffmpeg argv (JPEG resize, WebP resize, HEIC/AVIF to JPEG).
- Spawns tools with stdin ignored (`stdio: ["ignore", ...]`) so fd 0 is `/dev/null`.
- Keeps the existing `timeoutMs` on the spawn.
- Frees the Photon image if decoded dimensions fail the pixel budget (the decode already allocated it).

## Evidence

Live `node` on the patched tree, public `createRastermill({ execution: "external" }).encode(...)`. The injected ffmpeg child reported argv and the kind of fd 0:

```console
$ node --experimental-strip-types /tmp/rastermill-ffmpeg-proof.mjs
{
  "format": "jpeg",
  "width": 4,
  "height": 2,
  "ms": 240,
  "nostdin": true,
  "stdinKind": "char",
  "argsHead": ["-nostdin", "-y", "-i", ".../in.img"]
}
```

`stdinKind: "char"` is `/dev/null` (stdio ignore). The same encode path before the patch started with `["-y", "-i", ...]` and fd 0 was a pipe.

Live `node` `execFile` against Homebrew ffmpeg 9.0.1, parent leaves stdin open (the old Rastermill spawn shape). Overwrite prompt hangs until `SIGKILL`. `-nostdin` returns in 16ms:

```console
$ node --input-type=module /tmp/ffmpeg-held-stdin.mjs
{"label":"node-execFile-held-stdin-overwrite","ms":2004,"hang":true,"signal":"SIGKILL",
 "msg":"File '.../out.jpg' already exists. Overwrite? [y/N] "}
{"label":"node-execFile-nostdin-overwrite","ms":16,"hang":false}
{"label":"node-spawn-ignore-nostdin-y","ms":17,"hang":false,"extra":{"code":0}}
```

## Real behavior proof

- **Behavior or issue addressed:** ffmpeg fallback left stdin as an open pipe and omitted `-nostdin`, so a public auto/external encode can wait until `timeoutMs` instead of finishing on a valid file.
- **Real environment tested:** macOS 15, Node v26.7.0, Homebrew ffmpeg 9.0.1, Rastermill checkout `/tmp/oc-impl-rastermill-ffmpeg` on `fix/ffmpeg-nostdin`.
- **Exact steps or command run after this patch:** `node --experimental-strip-types /tmp/rastermill-ffmpeg-proof.mjs` (public `createRastermill` encode with an external ffmpeg stand-in that records argv and `fstat` on fd 0). Then `node --input-type=module` against real `ffmpeg` with held stdin, with and without `-nostdin`.
- **Evidence after fix:** terminal output above. After the patch the public encode reports `nostdin: true`, `stdinKind: "char"`, and finishes in 240ms. Real ffmpeg with `-nostdin` no longer waits on the overwrite prompt.
- **Observed result after fix:** JPEG/WebP/HEIC ffmpeg argv starts with `-nostdin -y`. Child stdin is a character device, not a held pipe. `timeoutMs` is unchanged.
- **What was not tested:** live HEIC decode through a system ffmpeg build that lacks the codec; Windows `NUL` stdin on a Windows runner.

Introduced in the original package commit [`54771fd`](https://github.com/openclaw/rastermill/commit/54771fd) (2026-05-25). No open PR already changes this path.
