### PR TITLE
fix(docs): build TOC from heading tokens

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -38,8 +38,9 @@ const orderedPages = navSections.flatMap(([, rels]) =>
 );
 
 for (const page of pages) {
-  const html = markdownToHtml(page.markdown, page.rel);
-  const toc = tocFromHtml(html);
+  const headings = [];
+  const html = markdownToHtml(page.markdown, page.rel, headings);
+  const toc = tocFromHeadings(headings);
   const index = orderedPages.findIndex((candidate) => candidate.rel === page.rel);
   const prev = index > 0 ? orderedPages[index - 1] : null;
   const next = index >= 0 && index < orderedPages.length - 1 ? orderedPages[index + 1] : null;
@@ -77,7 +78,7 @@ function pageHref(targetRel, currentRel) {
   );
 }
 
-function markdownToHtml(markdown, currentRel) {
+function markdownToHtml(markdown, currentRel, headings = []) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const html = [];
   let paragraph = [];
@@ -104,7 +105,9 @@ function markdownToHtml(markdown, currentRel) {
   };
   const flushBlockquote = () => {
     if (!blockquote.length) return;
-    html.push(`<blockquote>${markdownToHtml(blockquote.join("\n"), currentRel)}</blockquote>`);
+    html.push(
+      `<blockquote>${markdownToHtml(blockquote.join("\n"), currentRel, headings)}</blockquote>`,
+    );
     blockquote = [];
   };
 
@@ -159,6 +162,9 @@ function markdownToHtml(markdown, currentRel) {
       const text = heading[2].trim();
       const id = slug(text);
       const body = inline(text, currentRel);
+      if (level === 2 || level === 3) {
+        headings.push({ level, id, text: inlineText(text) });
+      }
       html.push(
         level === 1
           ? `<h1 id="${id}">${body}</h1>`
@@ -258,6 +264,20 @@ function inline(text, currentRel) {
   );
 }
 
+function inlineText(text) {
+  const stash = [];
+  let out = text.replace(/`([^`]+)`/g, (_, code) => {
+    stash.push(code);
+    return stashPlaceholder(stash.length - 1);
+  });
+  out = out
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1$2")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<(https?:\/\/[^\s<>]+)>/g, "$1");
+  return replaceStash(out, stash);
+}
+
 function rewriteHref(href, currentRel) {
   if (/^(https?:|mailto:|tel:|#)/.test(href)) return href;
   const [raw, hash = ""] = href.split("#");
@@ -270,22 +290,9 @@ function rewriteHref(href, currentRel) {
   return href;
 }
 
-function tocFromHtml(html) {
-  const items = [];
-  const matcher = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
-  let match;
-  while ((match = matcher.exec(html))) {
-    items.push({
-      level: Number(match[1]),
-      id: match[2],
-      text: match[3]
-        .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-        .replace(/<[^>]+>/g, "")
-        .trim(),
-    });
-  }
-  if (items.length < 2) return "";
-  return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${items
+function tocFromHeadings(headings) {
+  if (headings.length < 2) return "";
+  return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${headings
     .map((item) => `<a class="toc-l${item.level}" href="#${item.id}">${escapeHtml(item.text)}</a>`)
     .join("")}</nav>`;
 }

--- a/test/docs-site.test.ts
+++ b/test/docs-site.test.ts
@@ -1,0 +1,42 @@
+import { execFile } from "node:child_process";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const workspaces: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(workspaces.splice(0).map((workspace) => rm(workspace, { recursive: true })));
+});
+
+describe("docs site", () => {
+  it("escapes table-of-contents text directly from markdown headings", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "rastermill-docs-"));
+    workspaces.push(workspace);
+    await cp(path.join(process.cwd(), "docs"), path.join(workspace, "docs"), { recursive: true });
+
+    const source = path.join(workspace, "docs", "error-handling.md");
+    await writeFile(
+      source,
+      `${await readFile(source, "utf8")}\n## <script>alert(1)</script>\n`,
+      "utf8",
+    );
+
+    await execFileAsync(
+      process.execPath,
+      [path.join(process.cwd(), "scripts/build-docs-site.mjs")],
+      {
+        cwd: workspace,
+      },
+    );
+
+    const html = await readFile(path.join(workspace, "docs", "error-handling.html"), "utf8");
+    expect(html).toContain(
+      '<a class="toc-l2" href="#script-alert-1-script">&lt;script&gt;alert(1)&lt;/script&gt;</a>',
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+});


### PR DESCRIPTION
## Summary

- build documentation TOC entries from markdown heading tokens during rendering
- remove the rendered-HTML tag-stripping path flagged by CodeQL
- cover script-like heading text with an isolated docs-build regression test

## Root cause

The docs generator rendered markdown headings to HTML, then reparsed that generated HTML with regular expressions to remove anchor and formatting tags before building the TOC. CodeQL correctly identified the tag-removal step as incomplete multi-character sanitization.

The markdown renderer already owns the authoritative heading level, ID, and source text. This change carries those facts forward and escapes the resulting TOC text at the output boundary. The HTML reparsing and tag-stripping path is deleted.

Production delta: `scripts/build-docs-site.mjs` is +27/-20. The remaining +7 lines establish the heading-metadata owner boundary and preserve supported inline heading text.

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:coverage` (77 tests; 85.81% statements, 80.61% branches, 97.9% functions)
- `pnpm docs:check`
- `pnpm build`
- `pnpm pack --pack-destination /tmp/rastermill-pack-codeql`
- `node scripts/package-smoke.mjs /tmp/rastermill-pack-codeql`
- `git diff --check`

Fixes CodeQL alert #1 from default-setup run 32454557561.
