### PR TITLE
chore(release): prepare 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.4 - Unreleased
+## 0.3.4 - 2026-09-08
 
 - Decode supported BMP input through the existing bounded Photon encode path.
   Validate embedded JPEG/PNG payloads through Photon before native fallback,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rastermill",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Fast, portable image processing for Node agents.",
   "keywords": [
     "heic",


### PR DESCRIPTION
## Summary

- set the package version to `0.3.4`
- date the existing `0.3.4` changelog entry for September 8, 2026

## Verification

- `pnpm prepublishOnly`
- `pnpm docs:check`
- `npm pack --pack-destination <temporary-directory>`
- `node scripts/package-smoke.mjs <temporary-directory>`
- 137 tests passed, 1 platform-specific test skipped

## Release

After merge, create the signed `v0.3.4` tag and publish the verified tarball to npm with public access.

Punchcard-Session: golden-orchard-valley-56
